### PR TITLE
Temporarily force older libseat

### DIFF
--- a/initial-setup.spec.in
+++ b/initial-setup.spec.in
@@ -43,6 +43,8 @@ Requires(preun): systemd
 Requires(postun): systemd
 Requires: util-linux
 Conflicts: firstboot < 19.2
+# temporary workaround for https://github.com/QubesOS/qubes-issues/issues/9568
+Conflicts: libseat >= 0.9.0
 
 %description
 The initial-setup utility runs after installation.  It guides the user through


### PR DESCRIPTION
With libseat 0.9.1 (and probably 0.9.0 too) weston fails to start due to
not registering input devices. Temporarily force older version until
issue is fixed

https://github.com/QubesOS/qubes-issues/issues/9568